### PR TITLE
Remove potential error nest regarding object being Dynamic thus tolerating confusion over a database called db.

### DIFF
--- a/js/npm/mongodb/MongoDatabase.hx
+++ b/js/npm/mongodb/MongoDatabase.hx
@@ -16,7 +16,7 @@ import js.npm.mongodb.MongoOption.MongoUserOption;
  * @author Eduardo Pons - eduardo@thelaborat.org
  */
 @:native("require('mongodb').Db")
-extern class MongoDatabase implements Dynamic<Dynamic>
+extern class MongoDatabase
 //extends EventEmitter
 {
 	/**


### PR DESCRIPTION
using Dynamic here allow to write 
package db;
var db : Db;
[...]

db.Something

and db.Something maybe the var in a highter scope, let's say we just add all necessary extern and remove as much dynamics as we can? 

( Spent a few hours on this one ) 

Thanks a lot!