### PR TITLE
Callback type (for js.npm only)

### DIFF
--- a/js/npm/Callback.hx
+++ b/js/npm/Callback.hx
@@ -1,5 +1,7 @@
 package js.npm;
 
+import js.Error;
+
 typedef Callback0 = Null<Error> -> Void;
 
 typedef Callback1<A> = Null<Error> -> Null<A> -> Void;

--- a/js/npm/Callback.hx
+++ b/js/npm/Callback.hx
@@ -1,0 +1,9 @@
+package js.npm;
+
+typedef Callback0 = Null<Error> -> Void;
+
+typedef Callback1<A> = Null<Error> -> Null<A> -> Void;
+
+typedef Callback2<A,B> = Null<Error> -> Null<A> -> Null<B> -> Void;
+
+typedef Callback<T> = Callback1<T>;


### PR DESCRIPTION
Specify an optional typed callback typedef.

There is a lot of avoidable boilerplate when specifying function callbacks. Given creating externs is often a manual process, anything to cut down on boilerplate is helpful.

Since a more multi-platform generic version is not yet available, this only applies to the `js.npm` packages: https://github.com/HaxeFoundation/haxe/pull/4534

I didn't actually write this typedef, I copied it from somewhere else, and I don't have a record of where, but it's proved useful.

If approved, I'll be using it in all my future npm extern PRs. 